### PR TITLE
Add Linux start instance support

### DIFF
--- a/src/php_epics/Makefile
+++ b/src/php_epics/Makefile
@@ -5,7 +5,7 @@ include $(TOP)/configure/CONFIG
 
 LIBRARY_HOST = php_epics
 
-USR_CFLAGS  +=  -I/usr/include/php -I/usr/include/php/Zend -I/usr/include/php/TSRM -I/usr/include/php/main \
+USR_CFLAGS  +=  -I/usr/include/php5 -I/usr/include/php5/Zend -I/usr/include/php5/TSRM -I/usr/include/php5/main \
    -DUNAME="\"UNAME=$(UNAME)\"" \
    -DLOGINDATE="\"LOGINDATE=$(LOGINDATE)\"" -DUNIX  \
    $(SERVER_CFLAGS) -DCOMPILE_DL=1 -DPNG_SETJMP_NOT_SUPPORTED -DHAVE_PHP_STREAM

--- a/src/php_epics/Makefile
+++ b/src/php_epics/Makefile
@@ -6,6 +6,7 @@ include $(TOP)/configure/CONFIG
 LIBRARY_HOST = php_epics
 
 USR_CFLAGS  +=  -I/usr/include/php5 -I/usr/include/php5/Zend -I/usr/include/php5/TSRM -I/usr/include/php5/main \
+                -I/usr/include/php -I/usr/include/php/Zend -I/usr/include/php/TSRM -I/usr/include/php/main \
    -DUNAME="\"UNAME=$(UNAME)\"" \
    -DLOGINDATE="\"LOGINDATE=$(LOGINDATE)\"" -DUNIX  \
    $(SERVER_CFLAGS) -DCOMPILE_DL=1 -DPNG_SETJMP_NOT_SUPPORTED -DHAVE_PHP_STREAM


### PR DESCRIPTION
Updated php_epics Makefile to use PHP5 directories.

The directories appear to be specific to Linux, so I assume this won't affect Windows?

It may be cleaner to do this in a way that ensures the correct directories are always found, regardless of what they are on the current system... But I'm not sure if that is necessary for this?
