### PR TITLE
Move .project onto new line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ runIOC.sh
 relPaths.sh
 /html
 /src/edm/html/HTML.h
-/src/edm/html/html.h.project
+/src/edm/html/html.h
+.project


### PR DESCRIPTION
Previous scripted addition of .project to gitignore left some files with two entries on the same line
